### PR TITLE
The CLI could not tell a flag it did not know from one it had handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img width="1500" height="1024" alt="Image" src="https://github.com/user-attachments/assets/38a9afb6-3570-4797-ba57-488e004f4e66" />
 
 A functional systems programming language for humans and agents.
-Axiom blends the expressive power of functional programming with the performance and control of systems languages. It uses a clean Lisp‑style S‑expression syntax, a Hindley–Milner‑inspired type system, and an LLVM backend to produce fast, native executables — with no VM and no runtime. Memory comes from an `mmap`-backed bump allocator by default; `--gc` swaps in a tracing collector for programs that need peak memory to track live data.
+Axiom blends the expressive power of functional programming with the performance and control of systems languages. It uses a clean Lisp‑style S‑expression syntax, a Hindley–Milner‑inspired type system, and an LLVM backend to produce fast, native executables — with no VM and no runtime. Memory comes from an `mmap`-backed bump allocator, with explicit arena reclamation where peak memory matters.
 
 Axiom is intentionally small, explicit, and transparent. It’s designed not only for developers, but also for agentic programming, where AI systems generate, analyze, and manipulate code. Its uniform structure and predictable semantics make it uniquely easy for agents to understand and work with.
 
@@ -546,12 +546,15 @@ What works, and what to know:
   at contiguous 8-byte offsets (no tag word).
 - **Named fields per variant** work - see [Struct variants](#struct-variants).
 - **Allocation** comes from an `mmap`-backed bump allocator, not `malloc`,
-  and by default nothing is ever freed, so memory use tracks *total*
-  allocations rather than live data. `--gc` swaps in a tracing collector
-  and makes peak memory track the live set instead: on
-  `tests/stdlib/170-gc.ax`, 400 MB churned goes from 352 MB to 3.2 MB.
-  Neither is the end state - see the memory model in
-  [docs/v1-roadmap.md](docs/v1-roadmap.md).
+  and nothing is freed implicitly, so memory use tracks *total*
+  allocations rather than live data. `__axiom_arena_mark` and
+  `__axiom_arena_reset` reclaim explicitly by rolling the allocator's
+  waterline back, which is how the language server holds flat memory
+  across an editing session. There is no tracing collector: the retired
+  Rust compiler had one behind `--gc`, it was not ported, and the flag is
+  now refused by name rather than silently ignored
+  (`docs/self-hosting.md` §8.4). Not the end state - see the memory model
+  in [docs/v1-roadmap.md](docs/v1-roadmap.md).
 - **Field access by name** works on `data` and `struct` alike: `s.r`
   reads a field of a value whose constructor declared one.
 
@@ -1200,7 +1203,7 @@ the pipeline above is a module you can read in the language it compiles.
 | FFI | **Complete, no longer required** | Call any C function with `foreign` declarations. The standard library no longer uses it: see [Standard library](#standard-library) |
 | Standard library | **Functional** | `Pre`, `Mem`, `Str`, `Vec`, `Map`, `Fmt`, `Intern`, `Sys`, `IO`, written in Axiom over syscall primitives. `Vec`/`Map`/`Intern` are golden-tested and validated at 10⁵ elements; against Rust at 10⁶, `Intern` is *faster* (0.75×), `Vec` is 2.5×, and `Map` is 14× — six sevenths of which is table growth against the bump allocator, not hashing. `scripts/bench-datastructures.sh` |
 | Syscalls | **Complete** | `__syscall0`-`__syscall6` on Darwin and Linux, x86-64 and AArch64; errors normalised to `-errno` on every platform |
-| Allocation | **Functional; unbounded by default** | `mmap`-backed bump allocator emitted by the backend, overridable by defining `axiom_alloc`. No `free`, so memory tracks *total* allocations. `--gc` swaps in a conservative non-moving mark-sweep collector and makes peak memory track the live set: 400 MB churned goes from 352 MB to 3.2 MB. Neither is the end state; see the memory model in [docs/v1-roadmap.md](docs/v1-roadmap.md) |
+| Allocation | **Functional; unbounded by default** | `mmap`-backed bump allocator emitted by the backend, overridable by defining `axiom_alloc`. No `free`, so memory tracks *total* allocations; `__axiom_arena_mark`/`__axiom_arena_reset` reclaim explicitly where peak memory matters. No tracing collector — the Rust compiler's `--gc` was not ported and the flag is now refused (`docs/self-hosting.md` §8.4). Not the end state; see the memory model in [docs/v1-roadmap.md](docs/v1-roadmap.md) |
 | Cross-compilation | **Functional** | `--target` selects ABI and platform stdlib modules; codegen verified for all four targets |
 | Self-hosting | **Done** | Axiom's compiler is written in Axiom. It compiles itself and reproduces itself byte-for-byte (`stage2 == stage3`, as objects and as IR), and a clean checkout builds it from `bootstrap/` with nothing but `llc` and a C linker. The Rust implementation it replaced has been removed. See [docs/self-hosting.md](docs/self-hosting.md) |
 | ADTs / data types | **Complete** | Constructors (nullary and with fields, including recursive types like `List`/`Tree`) compile to heap-boxed tagged values; see [Algebraic data types](#algebraic-data-types-how-they-actually-run) |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,6 +1,6 @@
 # Axiom Language Reference
 
-A friendly, comprehensive guide to the Axiom programming language — a functional systems language that compiles to native code via LLVM, with no VM and no runtime. Memory comes from an `mmap`-backed bump allocator by default; `--gc` swaps in a tracing collector for programs that need peak memory to track live data.
+A friendly, comprehensive guide to the Axiom programming language — a functional systems language that compiles to native code via LLVM, with no VM and no runtime. Memory comes from an `mmap`-backed bump allocator.
 
 ---
 
@@ -1276,27 +1276,20 @@ axiom run source.ax
 # exits in milliseconds, and it costs nothing at runtime.
 axiom build --input source.ax --output program
 
-# A conservative mark-sweep collector, so peak memory tracks *live* data.
-# Pays a collection pause whenever the current mapping fills.
-axiom --gc build --input source.ax --output program
 ```
 
-Both are freestanding — neither calls libc. `--gc` is a global flag, so
-it goes before the subcommand, and it applies to `run` and `emit-llvm`
-too.
+The build is freestanding — it does not call libc.
 
-The collector is conservative: it treats any word that could be a
-pointer to a live object as one, because Axiom values are untyped machine
-words at runtime. An integer that happens to equal a live object's
-address keeps that object alive. It never moves anything, so pointer
-identity holds.
-
-`__axiom_arena_mark`, `__axiom_arena_reset` and
-`__axiom_arena_reset_keeping` belong to the bump allocator and are a
-compile error under `--gc`: a tracing collector reclaims by
-reachability and has no waterline to roll back to. They are also a
-compile error in a program that defines its own `axiom_alloc`, which
-replaces the allocator whose position they move.
+There is no tracing collector. The retired Rust compiler had one behind
+a `--gc` flag; it was not ported, and `--gc` is now refused by name
+rather than silently ignored (see `docs/self-hosting.md` §8.4). Peak
+memory therefore tracks *total* allocation, not live data. Where that
+matters, `__axiom_arena_mark`, `__axiom_arena_reset` and
+`__axiom_arena_reset_keeping` let a program reclaim explicitly by
+rolling the allocator's waterline back — which is how the language
+server holds flat memory across an editing session. They are a compile
+error in a program that defines its own `axiom_alloc`, which replaces
+the allocator whose position they move.
 
 The three carry a contract the compiler cannot check: after a reset,
 nothing allocated since the matching mark may be read again. What the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -240,11 +240,16 @@ still proportional to total allocations, not live data. Acceptable for
 a single-shot compiler process, and worth revisiting before anything
 long-running is written in Axiom.
 
-*The collector, and why it is shaped the way it is.* `--gc` replaces the
-bump allocator with a conservative, non-moving mark-sweep collector, so
-peak memory tracks live data instead of total allocation. Measured on
-`tests/stdlib/170-gc.ax`, which churns garbage while holding a list
-alive:
+*The collector, and why it was shaped the way it was.* **This section
+describes the RETIRED Rust compiler. `--gc` no longer exists** — the
+collector was not ported and the flag is refused by name; see §8.4. The
+numbers and the design are kept because they are the measured case for
+building one again, not because the current compiler behaves this way.
+
+`--gc` replaced the bump allocator with a conservative, non-moving
+mark-sweep collector, so peak memory tracked live data instead of total
+allocation. Measured on `tests/stdlib/170-gc.ax`, which churns garbage
+while holding a list alive:
 
 | churned | bump allocator | `--gc` |
 |---|---:|---:|
@@ -4013,6 +4018,22 @@ Recorded as this compiler's behaviour rather than fixed to match:
 - **Parse-error codes differ on some malformed input** (AX2001 vs AX2002
   vs AX2003). Spans and exit statuses agree; only the code differs, on
   input that is refused either way.
+- **`--gc` is gone, and is now refused by name.** The Rust compiler had
+  it as a global boolean that swapped the bump allocator for a
+  conservative mark-sweep collector — 1,098 lines in
+  `axiom-codegen/src/gc.rs`, deleted with the rest of the crate in
+  `430a138`. Nothing in `self_host/` replaced it, and the flag was
+  neither implemented nor rejected, so `axiom --gc build …` produced a
+  bump-allocator binary and said nothing. That was worse than an
+  unimplemented flag: `scripts/bench-datastructures.sh --gc` was
+  reporting collector numbers for an allocator binary, and README.md's
+  opening paragraph and `docs/reference.md` both promised a memory model
+  the compiler did not have. A silent downgrade of a memory-management
+  request is precisely the failure its user cannot detect, so the flag
+  is now a hard, named refusal (exit 2) and the three documents no
+  longer claim it. **This is a capability loss, not a CLI decision**: if
+  peak memory tracking live data matters again, the collector has to be
+  written in Axiom, and that is a project, not a slice.
 
 One divergence found during this work is recorded as a **defect, not a
 decision**, because after the deletion there is no second implementation

--- a/scripts/bench-datastructures.sh
+++ b/scripts/bench-datastructures.sh
@@ -40,15 +40,15 @@
 #     one.
 #
 #   - Axiom allocates from a bump allocator and never frees, so it does
-#     no deallocation work at all, while Rust's `Drop` runs. `--gc`
-#     measures the collected variant, which is the honest comparison for
-#     anything long-running.
+#     no deallocation work at all, while Rust's `Drop` runs. There is no
+#     longer a collected variant to measure against: the Rust
+#     compiler's `--gc` was not ported (docs/self-hosting.md 8.4), so
+#     this comparison is bump-allocator-versus-Drop and says so.
 #
 # Usage:
 #   scripts/bench-datastructures.sh              # table only
 #   scripts/bench-datastructures.sh --check      # enforce the 2x bound
 #   scripts/bench-datastructures.sh --fx         # fast hasher on the Rust side
-#   scripts/bench-datastructures.sh --gc         # Axiom under --gc
 #   scripts/bench-datastructures.sh --opt=0      # axiom unoptimised
 #   N=100000 scripts/bench-datastructures.sh     # a different scale
 
@@ -74,7 +74,6 @@ N="${N:-1000000}"
 REPS="${REPS:-7}"
 check=0
 fx=0
-use_gc=0
 # Axiom's optimisation level. The Rust side is always `rustc -O`, so
 # comparing against Axiom's default `-O0` measures the absence of an
 # optimiser as much as the data structure. `--opt 2` is what the
@@ -85,7 +84,13 @@ for arg in "$@"; do
   case "$arg" in
     --check) check=1 ;;
     --fx)    fx=1 ;;
-    --gc)    use_gc=1 ;;
+    # `--gc` used to set a flag that was passed to the compiler,
+    # silently ignored by it, and then printed in the results banner -
+    # so the table said "axiom under --gc" while measuring the bump
+    # allocator. Refused rather than quietly dropped: a benchmark that
+    # answers a question it did not measure is worse than one that
+    # declines to.
+    --gc)    echo "error: --gc was not ported to the self-hosted compiler; there is no collected variant to measure (docs/self-hosting.md 8.4)" >&2; exit 2 ;;
     --opt=*) opt="${arg#--opt=}" ;;
     *) echo "unknown option: $arg" >&2; exit 2 ;;
   esac
@@ -267,11 +272,7 @@ for b in empty vec map intern; do
     echo "error: could not build the Rust $b benchmark" >&2
     tail -20 "$work/rustc.log" >&2; exit 1
   }
-  if [[ $use_gc -eq 1 ]]; then
-    build=("$axiom" --gc build)
-  else
-    build=("$axiom" build)
-  fi
+  build=("$axiom" build)
   "${build[@]}" --opt "$opt" --input "$work/b_$b.ax" --output "$work/ax_$b" \
     >"$work/build.log" 2>&1 || {
     echo "error: could not build the Axiom $b benchmark" >&2
@@ -326,7 +327,6 @@ done
 printf '\nn=%s, axiom --opt %s vs rustc -O, best of %s runs, startup subtracted ' "$N" "$opt" "$REPS"
 printf '(axiom %ss, rust %ss)' "$ax_startup" "$rs_startup"
 [[ $fx -eq 1 ]] && printf ', rust using a fast non-cryptographic hasher'
-[[ $use_gc -eq 1 ]] && printf ', axiom under --gc'
 printf '\n'
 
 exit $status

--- a/scripts/bootstrap-from-seed.sh
+++ b/scripts/bootstrap-from-seed.sh
@@ -126,12 +126,17 @@ cc "$work/seed.o" -o "$work/seed" -e _main 2>"$work/cc.err" \
   || { head -3 "$work/cc.err" >&2; fail "could not link the seed"; }
 echo "ok   seed built for $target from $seed_ll (no Rust)"
 
-# A stage reads `in.ax` and writes LLVM to stdout, so compiling the
-# compiler means feeding it its own entry point.
+# A stage compiles the file it is given and writes LLVM to stdout, so
+# compiling the compiler means feeding it its own entry point.
+#
+# The filename is passed explicitly. It used to be omitted, relying on a
+# bare invocation defaulting to `in.ax` - a default that made `axiom`
+# with no arguments answer `cannot read input: in.ax`, naming a file the
+# user never typed. The default is gone; every caller says what it means.
 build_next() {
   local from="$1" out_ll="$2" out_bin="$3"
   cp "$repo_root/self_host/main.ax" "$work/in.ax"
-  (cd "$work" && "./$from" >"$out_ll" 2>"$out_ll.err") \
+  (cd "$work" && "./$from" in.ax >"$out_ll" 2>"$out_ll.err") \
     || { head -5 "$work/$out_ll.err" >&2; fail "$from could not compile self_host/main.ax"; }
   # Blame the stage that produced the garbage, not the tool that
   # chokes on it. Ablated with a seed that was a valid Axiom program

--- a/scripts/check-bootstrap.sh
+++ b/scripts/check-bootstrap.sh
@@ -221,12 +221,12 @@ cc "$work/seed.o" -o "$work/seed" -e _main 2>"$work/cc.err" \
 echo "ok   seed built for $target from $seed_ll (no Rust, no cargo)"
 
 # Build the next stage from a stage that has no driver yet: the stage
-# reads `in.ax` and writes LLVM to stdout, so compiling the compiler
-# means feeding it its own entry point.
+# compiles the file it is given and writes LLVM to stdout, so compiling
+# the compiler means feeding it its own entry point.
 build_next() {
   local from="$1" out_ll="$2" out_bin="$3"
   cp "$repo_root/self_host/main.ax" "$work/in.ax"
-  (cd "$work" && "./$from" >"$out_ll" 2>"$out_ll.err") \
+  (cd "$work" && "./$from" in.ax >"$out_ll" 2>"$out_ll.err") \
     || { head -5 "$work/$out_ll.err" >&2; fail "$from could not compile self_host/main.ax"; }
   # Blame the stage that produced the garbage, not the tool that chokes
   # on it: without these two lines a seed that was a valid Axiom
@@ -254,7 +254,7 @@ check_runs() {
 (:: main Int)
 (fn (main) (add 40 2))
 CASE
-  (cd "$work" && "./$stage" >"prog.ll" 2>/dev/null) || fail "$stage could not compile the probe"
+  (cd "$work" && "./$stage" in.ax >"prog.ll" 2>/dev/null) || fail "$stage could not compile the probe"
   llc -filetype=obj -relocation-model=pic "$work/prog.ll" -o "$work/prog.o" 2>/dev/null || fail "$stage emitted IR llc rejects"
   cc "$work/prog.o" -o "$work/prog" -e _main 2>/dev/null || fail "$stage emitted an object that will not link"
   (cd "$work" && ./prog)

--- a/scripts/check-driver.sh
+++ b/scripts/check-driver.sh
@@ -172,6 +172,379 @@ else
   sed 's/^/    /' f2.log | head -3
 fi
 
+# ---------------------------------------------------------------
+# Argument parsing: a boolean flag must not eat the file after it.
+#
+# The scan that finds the first positional used to skip TWO arguments
+# for any flag without an `=`, on the assumption that every flag takes
+# a value. Six do; the rest are booleans. So
+#
+#     axiom --emit-llvm prog.ax
+#
+# read `prog.ax` as the value of `--emit-llvm`, found no positional,
+# and compiled the default `in.ax` - reporting `cannot read input:
+# in.ax` about a file the user never typed, while their filename sat
+# in argv.
+#
+# The assertion is about ARGV, not about any golden: whatever the
+# compiler says, it must name the file it was given. A wrong answer
+# here cannot be blessed away, because the expected string is built
+# from the argument the test itself passed.
+for flag in --emit-llvm --check --builtins --list; do
+  "$s1" "$flag" nosuch-$$.ax >p.out 2>p.err; rc=$?
+  if grep -q "nosuch-$$\.ax" p.err; then
+    ok "\`$flag FILE\` names FILE, not a default"
+  elif grep -q 'in\.ax' p.err; then
+    bad "\`$flag FILE\` swallowed the filename and reported in.ax (rc=$rc)"
+  else
+    bad "\`$flag FILE\` (rc=$rc) said: $(head -1 p.err)"
+  fi
+done
+
+# The same flags, with a file that EXISTS, must actually compile it.
+"$s1" --emit-llvm hello.ax >p2.out 2>p2.err; rc=$?
+if [[ $rc == 0 ]] && grep -q '^target triple' p2.out; then
+  ok "\`--emit-llvm FILE\` compiles FILE"
+else
+  bad "\`--emit-llvm FILE\` (rc=$rc): $(head -1 p2.err)"
+fi
+
+# No arguments at all: usage, not a complaint about a file nobody named.
+"$s1" >n.out 2>n.err; rc=$?
+if [[ $rc != 0 ]] && grep -q 'USAGE' n.err && ! grep -q 'in\.ax' n.err; then
+  ok "a bare invocation prints usage and fails"
+else
+  bad "a bare invocation (rc=$rc) said: $(head -1 n.err)"
+fi
+
+# ---------------------------------------------------------------
+# The entry point is the program's business, not the toolchain's.
+#
+# A file with no `main` used to reach codegen, which emits the argv
+# wrapper's `call @__axiom_user_main` unconditionally, and the omission
+# surfaced from `opt` as `use of undefined value '@__axiom_user_main'`
+# against a `.ll` the driver had already deleted - exit 4, "a native
+# tool failed", for a program that was simply missing its entry point.
+# AX4001 was in the code table and in `axiom explain` the whole time
+# with nothing constructing it.
+#
+# Asserting the CODE and the absence of the toolchain's noise, because
+# the status alone does not discriminate: exit 1 is also what a failing
+# check gives, and a driver that merely stopped earlier for some other
+# reason would satisfy a status-only test.
+printf '(:: helper (-> Int Int))\n(fn (helper x) x)\n' >nomain.ax
+"$s1" build --input nomain.ax --output nm >nm.out 2>nm.err; rc=$?
+if [[ $rc == 1 ]] && [[ ! -f nm ]] \
+   && grep -q 'AX4001' nm.err \
+   && grep -q 'no `main` function found' nm.err \
+   && ! grep -q '__axiom_user_main' nm.err \
+   && ! grep -q 'opt' nm.err; then
+  ok "a program with no \`main\` is AX4001 and exit 1, not an llc error"
+else
+  bad "no-main (rc=$rc): $(head -1 nm.err)"
+fi
+
+# The help has to be actionable, since this is the commonest thing a
+# newcomer gets wrong.
+grep -q 'add `(:: main Int)`' nm.err \
+  && ok "AX4001 says how to fix it" || bad "AX4001 help text"
+
+# ...and it must NOT over-fire. These three surfaces analyse a module
+# without producing an executable, so a library with no entry point is
+# perfectly well-formed to them. The legacy no-subcommand spelling is
+# the load-bearing one: check-diagnostics.sh sweeps every file in
+# self_host/, stdlib/, stdlib/Sys/, tests/stdlib/ and tests/selfhost/
+# through it and requires exit 0, and most of those modules have no
+# `main` at all.
+"$s1" check nomain.ax >/dev/null 2>&1 \
+  && ok "\`check\` accepts a module with no \`main\`" || bad "check over-fires AX4001"
+"$s1" emit-llvm nomain.ax >/dev/null 2>&1 \
+  && ok "\`emit-llvm\` accepts a module with no \`main\`" || bad "emit-llvm over-fires AX4001"
+"$s1" nomain.ax >legacy-nomain.ll 2>/dev/null && grep -q '^target triple' legacy-nomain.ll \
+  && ok "the legacy spelling accepts a module with no \`main\`" \
+  || bad "the legacy spelling over-fires AX4001 - check-diagnostics.sh sweeps main-less modules through it"
+
+# ---------------------------------------------------------------
+# An empty file is READ, not refused.
+#
+# `sysReadFile` answers "" for a missing file and for an empty one, so
+# both reported `cannot read input` - a statement about the filesystem,
+# and false for the second. An empty file is a module with no
+# declarations: it checks clean, and only `build` rejects it, for the
+# reason that is actually true.
+: >empty.ax
+"$s1" check empty.ax >e.out 2>e.err; rc=$?
+if [[ $rc == 0 ]] && grep -q 'OK' e.out; then
+  ok "an empty file checks clean"
+else
+  bad "empty file check (rc=$rc): $(head -1 e.err)"
+fi
+"$s1" build --input empty.ax --output ef >/dev/null 2>ef.err; rc=$?
+if [[ $rc == 1 ]] && grep -q 'AX4001' ef.err; then
+  ok "an empty file fails to BUILD, for want of an entry point"
+else
+  bad "empty file build (rc=$rc): $(head -1 ef.err)"
+fi
+
+# ---------------------------------------------------------------
+# One spelling for an unreadable entry file, and it says WHY.
+#
+# There were three wordings - `cannot read input: F` from the compile
+# path, `Failed to read file 'F'` from fmt and symbols, and nothing at
+# all distinguishing a missing file from a directory - so which message
+# a user saw depended on which subcommand they had typed, and none of
+# them ever said whether the file was absent, unreadable, or a
+# directory. The REASON is what pins this: no previous version printed
+# one, so a re-blessed golden cannot satisfy it by accident.
+for sub in "check" "fmt" "symbols"; do
+  "$s1" $sub no-such-file.ax >/dev/null 2>r.err
+  if grep -q "Failed to read file 'no-such-file.ax': No such file or directory" r.err; then
+    ok "\`$sub\` names the file and the reason it could not be read"
+  else
+    bad "\`$sub\` read failure: $(head -1 r.err)"
+  fi
+done
+"$s1" build --input no-such-file.ax --output x >/dev/null 2>r2.err
+grep -q "Failed to read file 'no-such-file.ax': No such file or directory" r2.err \
+  && ok "\`build\` uses the same wording" || bad "build read failure: $(head -1 r2.err)"
+
+# A directory opens happily on both Darwin and Linux and fails at
+# `read`, so it is the case a missing-file-only probe gets wrong.
+mkdir -p adir
+"$s1" check adir >/dev/null 2>d.err
+grep -q "Failed to read file 'adir': Is a directory" d.err \
+  && ok "a directory is reported as a directory" || bad "directory: $(head -1 d.err)"
+
+# ---------------------------------------------------------------
+# THE DATA LOSS. Two spellings of `fmt` used to rewrite the user's file
+# and report success, because argument parsing could not say that an
+# argument was not a flag it knew:
+#
+#   fmt --check=true F   `hasFlag` matched EXACTLY, so `--check=true`
+#                        was not `--check`, and the arm fell through to
+#                        the write path.
+#   fmt F --help         `--help` was recognised only at argv[1].
+#
+# Both assertions are about the FILE, not about a message: whatever the
+# compiler says, F must come back byte-identical. That cannot be blessed
+# away, because the expected content is the input the test itself wrote.
+printf '(:: main Int)\n(fn (main)   42)\n' >dl.ax
+cp dl.ax dl.orig
+
+"$s1" fmt --check=true dl.ax >dl1.out 2>dl1.err; rc=$?
+if cmp -s dl.ax dl.orig && [[ $rc == 2 ]]; then
+  ok "\`fmt --check=true FILE\` refuses and leaves FILE untouched"
+else
+  bad "\`fmt --check=true FILE\` (rc=$rc) rewrote the file or accepted it"
+fi
+
+cp dl.orig dl.ax
+"$s1" fmt dl.ax --help >dl2.out 2>dl2.err; rc=$?
+if cmp -s dl.ax dl.orig && [[ $rc == 0 ]] && grep -q 'axiom fmt' dl2.out; then
+  ok "\`fmt FILE --help\` prints fmt's help and leaves FILE untouched"
+else
+  bad "\`fmt FILE --help\` (rc=$rc) rewrote the file or printed no help"
+fi
+
+# ---------------------------------------------------------------
+# An unrecognised flag is an ERROR, not something stepped over.
+#
+# Skipping is indistinguishable from accepting, which is why
+# `check --bogus f.ax` printed OK and exited 0, and why a mistyped
+# `--diagnostic-formt=json` quietly produced human output.
+"$s1" check --bogus hello.ax >u1.out 2>u1.err; rc=$?
+if [[ $rc == 2 ]] && grep -q 'unrecognised flag' u1.err && grep -q 'bogus' u1.err; then
+  ok "an unrecognised flag is refused, naming the flag"
+else
+  bad "unknown flag (rc=$rc): $(head -1 u1.err)"
+fi
+
+# A value flag at the end of argv with nothing after it.
+"$s1" check hello.ax --target >u2.out 2>u2.err; rc=$?
+[[ $rc == 2 ]] && grep -q 'value is required' u2.err \
+  && ok "a value flag with no value is refused" || bad "missing flag value (rc=$rc)"
+
+# ---------------------------------------------------------------
+# A mistyped SUBCOMMAND is a subcommand error, not a file error.
+#
+# `axiom buidl f.ax` was read as the legacy `FILE TARGET` with
+# FILE=`buidl`, so the answer was `cannot read input: buidl` and the
+# user's real filename was discarded. `buidl`->`build` is a
+# TRANSPOSITION, which plain Levenshtein scores as two edits, so this
+# case is also what pins the suggestion threshold at 2 rather than 1.
+"$s1" buidl hello.ax >tc.out 2>tc.err; rc=$?
+if [[ $rc == 2 ]] && grep -q 'unrecognised subcommand' tc.err && grep -q 'build' tc.err; then
+  ok "a mistyped subcommand is refused, and suggests the real one"
+else
+  bad "typo'd subcommand (rc=$rc): $(head -1 tc.err)"
+fi
+
+# ...but a real file that merely looks nothing like a command keeps the
+# legacy reading, which is what the five harnesses depend on.
+"$s1" hello.ax >lg.ll 2>/dev/null && grep -q '^target triple' lg.ll \
+  && ok "a real file is still read as a file, not guessed at" || bad "legacy reading lost"
+
+# ---------------------------------------------------------------
+# `--gc` names a capability this compiler does not have.
+#
+# The retired compiler's tracing collector (1,098 lines, deleted with
+# the crate) was not ported. The flag was neither implemented nor
+# rejected, so `axiom --gc build ...` produced a bump-allocator binary
+# and said nothing - while README.md, docs/reference.md and
+# scripts/bench-datastructures.sh all still promised a collector. A
+# silent downgrade of a memory-management request is the one failure its
+# user cannot detect.
+"$s1" --gc build --input hello.ax --output gcout >gc.out 2>gc.err; rc=$?
+if [[ $rc == 2 ]] && grep -q 'gc' gc.err && [[ ! -f gcout ]]; then
+  ok "\`--gc\` is refused by name rather than silently ignored"
+else
+  bad "--gc (rc=$rc): $(head -1 gc.err)"
+fi
+
+# ---------------------------------------------------------------
+# Help, from anywhere, on stdout, exit 0.
+for c in build check run emit-llvm fmt explain symbols repl lsp; do
+  "$s1" $c --help >h.out 2>h.err; rc=$?
+  if [[ $rc == 0 ]] && grep -q "axiom $c" h.out; then
+    ok "\`$c --help\` prints $c's help"
+  else
+    bad "\`$c --help\` (rc=$rc)"
+  fi
+done
+
+# `axiom help <COMMAND>` answers for that command. The operand used to
+# be read and discarded, printing the general usage - while the COMMANDS
+# block promised this exact spelling. A usage text documenting behaviour
+# the binary lacks is the same defect as an unconstructed diagnostic code.
+for c in build fmt symbols; do
+  "$s1" help $c >hc.out 2>&1
+  grep -q "axiom $c" hc.out \
+    && ok "\`help $c\` answers for $c" || bad "\`help $c\` printed the general usage"
+done
+"$s1" help nosuchthing >hn.out 2>&1; rc=$?
+[[ $rc == 0 ]] && grep -q 'USAGE' hn.out \
+  && ok "\`help\` with an unknown topic falls back to the general usage" \
+  || bad "\`help nosuchthing\` (rc=$rc)"
+
+# The usage text and the flag table must not drift apart: every flag the
+# compiler accepts has to appear in `axiom --help`. Without this the two
+# have already diverged once - `repl` was dispatched but missing from
+# COMMANDS, and `--check`, `--builtins`, `--list` and `--no-banner` were
+# accepted but documented nowhere.
+"$s1" --help >full-help.txt 2>&1
+missing=""
+for f in --input --output -o --target --opt --emit-llvm --check --builtins \
+         --list --no-banner --diagnostic-format --help --version; do
+  grep -q -- "$f" full-help.txt || missing="$missing $f"
+done
+for c in build check run emit-llvm fmt explain symbols repl lsp version help; do
+  grep -q -- "  $c" full-help.txt || missing="$missing cmd:$c"
+done
+[[ -z "$missing" ]] && ok "every accepted flag and command appears in --help" \
+  || bad "undocumented in --help:$missing"
+
+# `-o` is the short form of `--output` under `build` too. Only
+# `emit-llvm` read it, so `axiom build -o prog f.ax` consumed `prog` as
+# a flag value and wrote the default `output` - while the usage text
+# listed `-o <PATH>` with no qualification.
+rm -f oprog output
+"$s1" build -o oprog hello.ax >ob.out 2>ob.err; rc=$?
+if [[ $rc == 0 ]] && [[ -x oprog ]]; then
+  ok "\`build -o PATH\` writes the executable to PATH"
+else
+  bad "build -o (rc=$rc, wrote $(ls output 2>/dev/null || echo nothing))"
+fi
+
+# `--opt` refuses a value it cannot honour instead of silently using 1,
+# in both spellings.
+for bad_opt in banana 9 300 ""; do
+  "$s1" build --input hello.ax --output oo --opt "$bad_opt" >oo.out 2>oo.err; rc=$?
+  [[ $rc == 2 ]] \
+    && ok "\`--opt $bad_opt\` is refused rather than silently building at -O1" \
+    || bad "\`--opt $bad_opt\` (rc=$rc) was accepted"
+done
+"$s1" build --input hello.ax --output oo --opt=banana >/dev/null 2>&1; [[ $? == 2 ]] \
+  && ok "\`--opt=banana\` is refused too" || bad "--opt= form not validated"
+
+# ...and it is refused BEFORE the compiler does the work, which is the
+# whole point of validating the command line in one pass. `--opt` used
+# to be parsed where it is USED - in `build`, after `compileFile` has
+# already run - so a command line that was wrong in two ways reported
+# the type error first and the bad flag only on the next run, after the
+# user had fixed the other thing.
+printf '(:: main Int)\n(fn (main) (nope 1))\n' >badopt.ax
+"$s1" build --input badopt.ax --output x --opt banana >bo.out 2>bo.err; rc=$?
+if [[ $rc == 2 ]] && grep -q 'opt' bo.err && ! grep -q 'AX3001' bo.err; then
+  ok "a bad flag is refused before the file is compiled"
+else
+  bad "flag/compile ordering (rc=$rc): $(head -1 bo.err)"
+fi
+rm -f oo
+"$s1" build --input hello.ax --output oo --opt 2 >/dev/null 2>&1 && [[ -x oo ]] \
+  && ok "a valid --opt still builds" || bad "--opt 2 regressed"
+
+# `-V` is the short form of `--version`, and `--` really ends option
+# parsing. Both were listed in the usage text before they worked: `-V`
+# printed the whole usage to stderr and exited 1, and `--` was accepted
+# by the validator and then ignored by the operand scan, so
+# `axiom check -- -weird.ax` still answered "check needs an input file".
+# A flag the help documents and the binary ignores is the same defect as
+# a diagnostic code nothing constructs.
+"$s1" -V >v.out 2>v.err; rc=$?
+[[ $rc == 0 ]] && grep -q 'axiom' v.out \
+  && ok "\`-V\` prints the version" || bad "\`-V\` (rc=$rc)"
+
+printf '(:: main Int)\n(fn (main) 1)\n' >./-weird.ax
+for sub in check symbols; do
+  "$s1" $sub -- -weird.ax >w.out 2>w.err; rc=$?
+  [[ $rc == 0 ]] \
+    && ok "\`$sub -- -weird.ax\` reaches a file whose name begins with a dash" \
+    || bad "\`$sub --\` (rc=$rc): $(head -1 w.err)"
+done
+# A LEADING-DASH code, which is the case only `--` can reach.
+# `explainNormalize` has always stripped leading dashes so that
+# `AX-3001` and `-3001` resolve, but nothing could deliver such a code
+# to it: the operand scan skipped any argument beginning with `-`. The
+# normaliser's dash-stripping was unreachable until now, and a plain
+# `explain -- 3001` would not have shown it, because that spelling
+# already worked by accident.
+"$s1" explain -- -3001 >x.out 2>&1
+grep -q 'AX3001' x.out \
+  && ok "\`explain -- -CODE\` reaches a code written with a leading dash" \
+  || bad "explain -- -3001: $(head -1 x.out)"
+
+# ---------------------------------------------------------------
+# `run` forwards what follows the file to the PROGRAM.
+#
+# It used to pass only the program's own name, so a program that reads
+# argv could not be given any arguments at all. Asserted numerically
+# through the program's own exit status, so no golden can bless it.
+cat >argc.ax <<'EOF'
+(import Sys)
+(:: main Int)
+(fn (main) (sysArgc))
+EOF
+"$s1" run argc.ax >/dev/null 2>&1; [[ $? == 1 ]] \
+  && ok "run with no arguments gives the program argc 1" || bad "run argc baseline"
+"$s1" run argc.ax alpha beta >/dev/null 2>&1; [[ $? == 3 ]] \
+  && ok "run forwards its trailing arguments to the program" || bad "run does not forward arguments"
+"$s1" run argc.ax -- --verbose x >/dev/null 2>&1; [[ $? == 3 ]] \
+  && ok "run passes dash-prefixed arguments through after \`--\`" || bad "run \`--\` passthrough"
+
+# ---------------------------------------------------------------
+# A successful command says so, and names what it produced.
+"$s1" build --input hello.ax --output bs >bs.out 2>&1
+grep -q 'Build successful: bs' bs.out \
+  && ok "a successful build names the executable it wrote" || bad "build success line"
+
+rm -f eo.ll
+"$s1" emit-llvm hello.ax --output eo.ll >eo.out 2>eo.err; rc=$?
+if [[ $rc == 0 ]] && [[ -s eo.ll ]] && grep -q 'LLVM IR written to eo.ll' eo.out; then
+  ok "\`emit-llvm --output\` writes the file and says where"
+else
+  bad "emit-llvm --output (rc=$rc, file $( [[ -s eo.ll ]] && echo written || echo MISSING))"
+fi
+
 echo
 echo "$passed passed, $failed failed"
 [[ "$failed" == 0 ]]

--- a/scripts/check-self-host.sh
+++ b/scripts/check-self-host.sh
@@ -95,10 +95,10 @@ for case_file in tests/selfhost/*.ax; do
     continue
   fi
 
-  # stage1 reads its input from the first argument (default in.ax) and
-  # writes LLVM to stdout.
+  # stage1 reads its input from the first argument and writes LLVM to
+  # stdout.
   cp "$case_file" "$work/in.ax"
-  if ! (cd "$work" && ./stage1 >out.ll 2>stage1.err); then
+  if ! (cd "$work" && ./stage1 in.ax >out.ll 2>stage1.err); then
     echo "FAIL $name (stage1 rejected it)"
     sed 's/^/    /' "$work/stage1.err" | head -3
     failed=$((failed + 1))
@@ -158,7 +158,7 @@ done
 # which is why this is not a corpus golden.
 if [[ -z "$filter" ]]; then
   printf '(import NoSuchModule)\n(:: main Int)\n(fn (main) 7)\n' >"$work/in.ax"
-  (cd "$work" && ./stage1 >/dev/null 2>neg.err)
+  (cd "$work" && ./stage1 in.ax >/dev/null 2>neg.err)
   neg_status=$?
   if [[ "$neg_status" == 1 ]] && grep -q "AX5001" "$work/neg.err" \
      && grep -q "NoSuchModule" "$work/neg.err" \

--- a/scripts/reseed.sh
+++ b/scripts/reseed.sh
@@ -48,7 +48,7 @@ if ! "$axiom" build --input self_host/main.ax --output "$work/gen" >"$work/build
   # `build --input` spelled that way only if it is very old; try the
   # plain form before giving up.
   cp "$repo_root/self_host/main.ax" "$work/in.ax"
-  (cd "$work" && "$axiom" >"$work/gen.ll" 2>/dev/null) \
+  (cd "$work" && "$axiom" in.ax >"$work/gen.ll" 2>/dev/null) \
     || { tail -20 "$work/build.log" >&2; fail "could not build a compiler with $axiom"; }
   llc -filetype=obj -relocation-model=pic "$work/gen.ll" -o "$work/gen.o" 2>/dev/null \
     || fail "llc rejected the IR from $axiom"

--- a/self_host/driver.ax
+++ b/self_host/driver.ax
@@ -11,7 +11,7 @@
 ; The argument grammar is STRICTLY ADDITIVE, and that is a constraint
 ; rather than a courtesy.
 ;
-; Five harnesses invoke stage1 as `stage1 [FILE [TARGET]]` -
+; Five harnesses invoke stage1 as `stage1 FILE [TARGET]` -
 ; check-self-host.sh, check-diagnostics.sh (twice), check-bootstrap.sh
 ; and check-stdlib-selfhost.sh. A subcommand CLI that replaced that
 ; spelling would break all five in the same commit, and they are the
@@ -21,9 +21,17 @@
 ; else keeps its old meaning as an input path.
 ;
 ; The cost of that rule is a file literally named `build`, `check`,
-; `run`, `emit-llvm` or `version` with no extension, which would be read
-; as a subcommand. Recorded rather than defended against: `--` handling
-; would be the fix if it ever mattered.
+; `run`, `emit-llvm` or `version` with no extension, which is read as a
+; subcommand. `--` now ends option parsing, which is the fix for a
+; filename beginning with a dash; a bare word that collides with a
+; subcommand name is still ambiguous and still resolves to the command.
+;
+; The ambiguity cuts the other way too, and used to cut silently:
+; `axiom buidl f.ax` was read as FILE=`buidl` TARGET=`f.ax` and answered
+; `cannot read input: buidl`, discarding the filename the user had
+; actually typed. `rejectTypoedSubcommand` breaks that tie by asking the
+; filesystem - an unreadable first operand within two edits of a command
+; name is a typo, not a file.
 ; ------------------------------------------------------------------
 
 (import core)
@@ -37,15 +45,30 @@
 ; ------------------------------------------------------------------
 ; Exit codes.
 ;
-; 0 success, 1 unreadable input, a failing check, or an unresolvable
-; import (AX5001 - stage0's code for it; stage1's old 3 retired
-; 2026-08-08 when the bare "cannot read module" line became a real
-; diagnostic, its only consumers being two gates updated in the same
-; commit), 2 a parse error. The toolchain adds 4
-; - a native tool failed or is missing - which is deliberately distinct
-; from 1, because "your program is wrong" and "llc is not installed" are
-; not the same news and a driver that reports them identically sends
-; the reader to the wrong place.
+;   0  success
+;   1  the PROGRAM is wrong: an unreadable input, a syntax error, a
+;      failing check, no entry point (AX4001), or an unresolvable import
+;      (AX5001 - stage0's code for it)
+;   2  the COMMAND LINE is wrong: an unknown command or flag, or a flag
+;      given the wrong number of values
+;   3  a module could not be read or parsed, or a target name is unknown
+;      - `dieImport`'s status, which the rest of the compiler reaches
+;      through codegen rather than through this file
+;   4  a native tool failed or is missing
+;
+; Two of these were previously documented wrongly in this comment, in
+; opposite directions, and the errors survived because nothing derived
+; the table from the code. It claimed 2 meant "a parse error" - untrue
+; since the parse-error port moved syntax errors to 1, leaving 2 unused
+; until usage errors took it - and it claimed 3 was "retired", which was
+; true only of the import path: `dieImport` still exits 3 from four
+; sites, and an entry file importing an unparsable module still does.
+;
+; 4 is deliberately distinct from 1 and is this compiler's own choice,
+; NOT the retired compiler's - that one exited 1 for a failing llc or
+; cc. The distinction is kept because "your program is wrong" and "llc
+; is not installed" are not the same news, and a driver that reports
+; them identically sends the reader to the wrong place.
 ; ------------------------------------------------------------------
 
 (pub :: exitToolFailed Int)
@@ -247,8 +270,9 @@
                       (|| (strEq s "repl")
                       (|| (strEq s "version")
                           (|| (strEq s "--version")
+                          (|| (strEq s "-V")
                               (|| (strEq s "help")
-                                  (|| (strEq s "--help") (strEq s "-h")))))))))))))))
+                                  (|| (strEq s "--help") (strEq s "-h"))))))))))))))))
 
 ; `--help` has to be recognised as a subcommand rather than parsed as a
 ; flag: the scan that lets global options precede a subcommand skips
@@ -258,9 +282,45 @@
 ; is a compiler nobody gets past.
 (pub :: usageText Int)
 (pub fn (usageText)
-  (cat3 "axiom (self-hosted) - the Axiom compiler, written in Axiom\n\nUSAGE:\n  axiom [OPTIONS] <COMMAND> [ARGS]\n  axiom <FILE> [TARGET]        emit LLVM IR to stdout\n\nCOMMANDS:\n  build    compile a source file to an executable\n  check    check syntax and types, emitting no code\n  run      compile a source file and run it\n  emit-llvm  print the generated LLVM IR\n  fmt      format a source file in place (--check to only report)\n  explain  describe a diagnostic code (--list for all codes)\n  symbols  list every top-level symbol in AXSYM (--builtins too)\n  lsp      run the language server on stdin/stdout (JSON-RPC)\n  version  print the version\n  help     print this message\n\n"
-        "OPTIONS:\n  --input <PATH>     input file (build; a bare path also works)\n  --output <PATH>    output file (build; default `output`)\n  -o <PATH>          output file (emit-llvm)\n  --target <NAME>    darwin-aarch64, darwin-x86_64, linux-aarch64, linux-x86_64\n  --opt <0-3>        optimisation level (default 1)\n  --emit-llvm        keep the generated .ll beside the executable\n  --diagnostic-format <human|ai|json>  how to render diagnostics (default human)\n\n"
-        "EXIT CODES:\n  0 success   1 bad input, a failing check, or an unresolvable import\n  2 parse error   4 a native tool failed or is missing\n"))
+  (cat3 "axiom - the Axiom compiler, written in Axiom\n\nUSAGE:\n  axiom [OPTIONS] <COMMAND> [ARGS]\n  axiom [OPTIONS] <FILE> [TARGET]   emit LLVM IR to stdout\n\nCOMMANDS:\n  build      compile a source file to an executable\n  check      check syntax and types, emitting no code\n  run        compile a source file and run it, forwarding any further ARGS\n  emit-llvm  print the generated LLVM IR\n  fmt        format a source file in place (--check to only report)\n  explain    describe a diagnostic code (--list for all codes)\n  symbols    list every top-level symbol in AXSYM (--builtins too)\n  repl       start the interactive read-eval-print loop\n  lsp        run the language server on stdin/stdout (JSON-RPC)\n  version    print the version\n  help       print this message, or `help <COMMAND>` for one command\n\n"
+        "OPTIONS:\n  --input <PATH>     input file (build; a bare path also works)\n  --output <PATH>    output file (build, emit-llvm; default `output`)\n  -o <PATH>          short for --output\n  --target <NAME>    darwin-aarch64, darwin-x86_64, linux-aarch64, linux-x86_64\n  --opt <0-3>        optimisation level (build, run; default 1)\n  --emit-llvm        keep the generated .ll beside the executable (build)\n  --check            report whether the file is formatted, do not write (fmt)\n  --builtins         also list the built-in operators (symbols)\n  --list             list every diagnostic code (explain)\n  --no-banner        skip the startup banner (repl)\n  --diagnostic-format <human|ai|json>  how to render diagnostics (default human)\n  -h, --help         print help; accepted anywhere, including after the file\n  -V, --version      print the version; before the command\n  --                 end of options, so a file whose name begins with `-`\n                     can be named at all\n\n"
+        "EXIT CODES:\n  0  success\n  1  the program is wrong: unreadable input, a syntax error, a failing\n     check, no entry point, or an unresolvable import\n  2  the command line is wrong: an unknown command or flag, or a flag\n     given the wrong number of values\n  3  a module could not be read or parsed, or a target name is unknown\n  4  a native tool failed or is missing (llc, cc)\n"))
+
+; One command's help: its synopsis and the flags it actually reads.
+;
+; `axiom build --help` used to answer `error: build needs an input
+; file` - the one question a CLI must never refuse. Worse,
+; `axiom fmt FILE --help` REWROTE the file, and `axiom repl --help`
+; dropped the user into the REPL, because `--help` was recognised only
+; at argv[1] and every other position fell through to the subcommand.
+;
+; A synopsis and a flag list rather than a page of prose: the flags are
+; the part a reader cannot guess, and check-driver.sh asserts that every
+; flag the table accepts appears in `axiom --help`, so the two cannot
+; drift apart silently.
+(pub :: helpForCommand (-> Int Int))
+(pub fn (helpForCommand c)
+  (if (strEq c "build")
+      "axiom build - compile a source file to an executable\n\nUSAGE:\n  axiom build [--input] <FILE> [--output <PATH>] [--opt <0-3>] [--emit-llvm]\n\n  --input <PATH>   the source file; a bare path works too\n  --output <PATH>  where to write the executable (default `output`)\n  -o <PATH>        short for --output\n  --opt <0-3>      optimisation level (default 1)\n  --emit-llvm      keep the generated .ll beside the executable\n"
+  (if (strEq c "check")
+      "axiom check - check syntax and types, emitting no code\n\nUSAGE:\n  axiom check <FILE>\n\nPrints `OK` and exits 0 when the module checks. Warnings are reported\nand do not fail. A module with no `main` checks clean: only `build`\nand `run` need an entry point.\n"
+  (if (strEq c "run")
+      "axiom run - compile a source file and run it\n\nUSAGE:\n  axiom run <FILE> [ARGS...]\n\nEverything after FILE is passed to the program, not read by the\ncompiler. Use `--` before an argument that begins with a dash. The\nprogram's own exit status becomes this command's.\n\n  --opt <0-3>      optimisation level (default 1)\n"
+  (if (strEq c "emit-llvm")
+      "axiom emit-llvm - print the generated LLVM IR\n\nUSAGE:\n  axiom emit-llvm <FILE> [-o <PATH>]\n\n  --output <PATH>  write the IR to PATH instead of stdout\n  -o <PATH>        short for --output\n\nA module with no `main` is fine here: no executable is produced.\n"
+  (if (strEq c "fmt")
+      "axiom fmt - format a source file in place\n\nUSAGE:\n  axiom fmt <FILE> [--check]\n\n  --check   report whether FILE is formatted and exit 1 if it is not,\n            WITHOUT writing to it\n\nThe formatter verifies before it writes: the output must re-parse, keep\nevery comment, and be a fixed point. A refusal leaves FILE untouched.\n"
+  (if (strEq c "explain")
+      "axiom explain - describe a diagnostic code\n\nUSAGE:\n  axiom explain <CODE>\n  axiom explain --list\n\nCODE may be written `AX3001`, `3001` or `ax-3001`.\n\n  --list    list every known code instead\n"
+  (if (strEq c "symbols")
+      "axiom symbols - list every top-level symbol, in AXSYM\n\nUSAGE:\n  axiom symbols <FILE> [--builtins]\n\n  --builtins   also list the always-in-scope operators\n\nAXSYM is the only rendering; --diagnostic-format applies to the\ndiagnostics on stderr, not to this output.\n"
+  (if (strEq c "repl")
+      "axiom repl - the interactive read-eval-print loop\n\nUSAGE:\n  axiom repl [--no-banner]\n\n  --no-banner   skip the startup banner\n\nType :help at the prompt for the meta-commands.\n"
+  (if (strEq c "lsp")
+      "axiom lsp - run the language server\n\nUSAGE:\n  axiom lsp\n\nSpeaks JSON-RPC over stdin and stdout, so it takes no operand and\nwrites nothing else to stdout.\n"
+  (if (strEq c "version")
+      "axiom version - print the version\n\nUSAGE:\n  axiom version\n  axiom --version\n"
+      usageText)))))))))))
 
 ; The value of `--name` / `--name=value`, or "" when absent.
 (pub :: flagValue (-> Int Int Int))
@@ -296,18 +356,111 @@
 ; `axiom --target=<t> emit-llvm <file> -o <out>`. Dispatching on argv[1]
 ; alone read `--target=linux-x86_64` as an input filename and answered
 ; `cannot read input`.
+; How many SEPARATE arguments this flag consumes after itself: 1 for a
+; value flag, 0 for a boolean, -1 when the name is not a flag at all.
+;
+; Kept as a table rather than inferred, because inferring it is what
+; broke. The scan below used to skip TWO arguments for any flag without
+; an `=`, on the assumption that a flag always takes a value, so
+;
+;     axiom --emit-llvm prog.ax
+;
+; read `prog.ax` as the VALUE of `--emit-llvm` and found no positional
+; after it. Any boolean flag before a positional did it. There is no way
+; to tell a boolean from a value-taking flag by looking at the flag.
+;
+; The -1 arm is the new half, and it is what makes an unrecognised flag
+; an ERROR rather than something silently stepped over. Skipping is
+; indistinguishable from accepting, which is why `axiom check --bogus
+; f.ax` used to print OK and exit 0, and why a mistyped
+; `--diagnostic-formt=json` quietly produced human output.
+(pub :: flagArity (-> Int Int))
+(pub fn (flagArity a)
+  (if (|| (strEq a "--input")
+      (|| (strEq a "--output")
+      (|| (strEq a "-o")
+      (|| (strEq a "--target")
+      (|| (strEq a "--opt")
+          (strEq a "--diagnostic-format"))))))
+      1
+  (if (|| (strEq a "--emit-llvm")
+      (|| (strEq a "--check")
+      (|| (strEq a "--builtins")
+      (|| (strEq a "--list")
+      (|| (strEq a "--no-banner")
+      (|| (strEq a "--gc")
+      (|| (strEq a "--help")
+      (|| (strEq a "-h")
+      (|| (strEq a "--version")
+          (strEq a "-V"))))))))))
+      0
+      (- 0 1))))
+
+; `--gc` is in the table above in order to be REFUSED by name.
+;
+; The retired compiler had `--gc` as a global boolean that swapped the
+; bump allocator for a 1,098-line mark-sweep collector
+; (axiom-codegen/src/gc.rs, deleted with the rest in 430a138). This
+; compiler has no collector at all. The flag was neither implemented nor
+; rejected, so `axiom --gc build ...` produced a bump-allocator binary
+; and said nothing - while README.md's opening paragraph, docs/reference.md
+; and scripts/bench-datastructures.sh all still promised a collector. A
+; benchmark labelled "axiom under --gc" was measuring the allocator it
+; existed to compare against.
+;
+; A silent downgrade of a memory-management request is exactly the
+; failure its user cannot detect, so this refuses while the collector
+; does not exist. Recorded in docs/self-hosting.md section 8.4.
+(pub :: flagUnimplemented (-> Int Bool))
+(pub fn (flagUnimplemented a) (strEq a "--gc"))
+
+; `--name=value` split into its two halves.
+(pub :: flagNamePart (-> Int Int))
+(pub fn (flagNamePart a)
+  (let ((e (strFindByte a 61 0)))
+    (if (< e 0) a (strSlice a 0 e))))
+
+(pub :: flagHasValuePart (-> Int Bool))
+(pub fn (flagHasValuePart a) (>= (strFindByte a 61 0) 0))
+
+(pub :: flagValuePart (-> Int Int))
+(pub fn (flagValuePart a)
+  (let ((e (strFindByte a 61 0)))
+    (if (< e 0) "" (strSlice a (+ e 1) (- (strLen a) (+ e 1))))))
+
+; Is this argument written as a flag at all? A bare `-` is not: it names
+; standard input by convention, and refusing it here would be a worse
+; answer than the read error a caller gives it.
+(pub :: looksLikeFlag (-> Int Bool))
+(pub fn (looksLikeFlag a)
+  (&& (strStartsWith a "-") (> (strLen a) 1)))
+
 (pub :: positionalIndex (-> Int Int))
 (pub fn (positionalIndex from)
   (if (>= from (sysArgc))
       (- 0 1)
       (let ((a (sysArg from)))
+        (if (strEq a "--")
+            ; `--` ends option parsing, so what follows is an operand
+            ; even when it begins with a dash. Without this the marker
+            ; was accepted by `checkArgs` and then ignored here, and
+            ; `axiom check -- -weird.ax` answered `check needs an input
+            ; file` - a separator the usage text documents and the
+            ; operand scan did not implement.
+            (if (< (+ from 1) (sysArgc)) (+ from 1) (- 0 1))
         (if (strStartsWith a "-")
-            ; A flag either carries its value with `=` or takes the next
-            ; argument, so skip one or two accordingly.
-            (if (>= (strFindByte a 61 0) 0)
+            ; A flag carries its value with `=`, or takes the next
+            ; argument, or takes none at all - and only the flag's name
+            ; can decide which. An unknown flag is stepped over here
+            ; rather than diagnosed, because `checkArgs` has already
+            ; refused the invocation before any of this runs; reaching
+            ; this point means every flag in argv is in the table.
+            (if (flagHasValuePart a)
                 (positionalIndex (+ from 1))
-                (positionalIndex (+ from 2)))
-            from))))
+                (if (== (flagArity a) 1)
+                    (positionalIndex (+ from 2))
+                    (positionalIndex (+ from 1))))
+            from)))))
 
 (pub :: positionalFrom (-> Int Int))
 (pub fn (positionalFrom from)
@@ -339,15 +492,258 @@
 (pub :: operandStart Int)
 (pub fn (operandStart) (+ subcommandIndex 1))
 
+; The optimisation level, refusing a value it cannot honour.
+;
+; It used to fall back to 1 for anything it did not recognise, so
+; `--opt banana` and `--opt 9` both built at -O1 in silence - the user
+; asked for one thing and got another with no way to tell. The retired
+; compiler parsed a u8 and clamped, so `--opt 200` also silently became
+; -O3; refusing outside 0-3 is stricter than that on purpose, because a
+; clamp is a silent answer to a question the user got wrong.
 (pub :: optLevelArg Int)
 (pub fn (optLevelArg)
+  ; `checkArgs` has already refused every value this cannot honour, so
+  ; the fallback here is unreachable rather than a silent substitution.
+  ; It is kept because the alternative is a partial function, and a
+  ; compiler that trusts an earlier pass to have run is one bad refactor
+  ; from building at the wrong level in silence.
   (let ((v (flagValue "--opt" 1)))
-    (if (== (strLen v) 0)
-        1
-        (let ((c (strByte v 0)))
-          (if (&& (>= c 48) (<= c 51)) (- c 48) 1)))))
+    (if (&& (== (strLen v) 1)
+            (let ((c (strByte v 0))) (&& (>= c 48) (<= c 51))))
+        (- (strByte v 0) 48)
+        1)))
 
 (pub :: targetArg (-> Int Int))
 (pub fn (targetArg fallback)
   (let ((v (flagValue "--target" 1)))
     (if (== (strLen v) 0) fallback v)))
+
+; ------------------------------------------------------------------
+; Validating the invocation, once, before any subcommand acts.
+;
+; Until this existed there was no such pass: `flagValue`, `hasFlag` and
+; `positionalIndex` each walked argv with its own idea of what a flag
+; was, and none could say that a flag was not one. Two of the results
+; destroyed a user's file:
+;
+;   axiom fmt --check=true FILE   REWROTE FILE and printed `OK: FILE
+;                                 formatted`. `hasFlag` matches exactly,
+;                                 so `--check=true` was not `--check`
+;                                 and the arm fell through to the write.
+;   axiom fmt FILE --help         REWROTE FILE, because `--help` was
+;                                 only ever recognised at argv[1].
+;
+; The rule is deliberately the WEAKEST one that kills the class: a flag
+; must EXIST and must be given the right number of values. It does NOT
+; police which subcommand owns which flag. That restraint is a gate
+; constraint, not tidiness - the legacy `axiom FILE [TARGET]` spelling
+; has no subcommand at all, and check-driver.sh requires
+; `axiom --emit-llvm hello.ax` to exit 0 with IR on stdout and
+; `axiom --check nosuch.ax` to name the file it could not read. Under
+; per-subcommand ownership those belong to `build` and `fmt`, so both
+; become usage errors and five gate cases flip. Existence and arity fix
+; the data loss and the silent typos without disturbing a single
+; existing invocation.
+; ------------------------------------------------------------------
+
+; A usage error: the message, a pointer at `--help`, and exit 2.
+;
+; 2 is the status the retired compiler used for every usage error (clap
+; 4.6.4's default), and it is free here: the parse-error port moved
+; syntax errors to 1, so nothing has produced 2 since. The split that
+; matters is stream and status together - help the user ASKED for goes
+; to stdout with 0, an invocation they got wrong goes to stderr with 2.
+(pub :: usageError (-> Int Int))
+;@axiom:effect(io)
+(pub fn (usageError msg)
+  {
+    (writeStderrStr msg)
+    (writeStderrStr "\nFor more information, try `axiom --help`.\n")
+    (sysExitWith 2)
+    2
+  })
+
+; Edit distance between `a` and `b`, two rows of the DP table.
+;
+; Only the SUBCOMMAND suggestion earns this. `axiom buidl f.ax` gave a
+; user no clue at all - it was read as a FILENAME, so the answer was
+; `cannot read input: buidl` and their real filename was discarded -
+; whereas `unrecognised flag `--diagnostic-formt`` already names the
+; thing that is wrong.
+(pub :: editDistance (-> Int Int Int))
+(pub fn (editDistance a b)
+  (let ((n (strLen a)) (m (strLen b)) (mut prev vecNew))
+    {
+      (let ((mut j 0))
+        (while (<= j m) { (vecPush prev j) (set j (+ j 1)) }))
+      (let ((mut i 1))
+        (while (<= i n)
+          (let ((cur vecNew))
+            {
+              (vecPush cur i)
+              (let ((mut j 1))
+                (while (<= j m)
+                  {
+                    (let ((cost (if (== (strByte a (- i 1)) (strByte b (- j 1))) 0 1)))
+                      (let ((d1 (+ (vecGet prev j) 1))
+                            (d2 (+ (vecGet cur (- j 1)) 1))
+                            (d3 (+ (vecGet prev (- j 1)) cost)))
+                        (vecPush cur (if (&& (<= d1 d2) (<= d1 d3))
+                                         d1
+                                         (if (<= d2 d3) d2 d3)))))
+                    (set j (+ j 1))
+                  }))
+              (set prev cur)
+              (set i (+ i 1))
+            })))
+      (vecGet prev m)
+    }))
+
+(pub :: subcommandNames Int)
+(pub fn (subcommandNames)
+  (let ((v vecNew))
+    {
+      (vecPush v (cast Int "build"))
+      (vecPush v (cast Int "check"))
+      (vecPush v (cast Int "run"))
+      (vecPush v (cast Int "emit-llvm"))
+      (vecPush v (cast Int "fmt"))
+      (vecPush v (cast Int "explain"))
+      (vecPush v (cast Int "symbols"))
+      (vecPush v (cast Int "repl"))
+      (vecPush v (cast Int "lsp"))
+      (vecPush v (cast Int "version"))
+      (vecPush v (cast Int "help"))
+      v
+    }))
+
+; The known subcommand within two edits of `w`, or "".
+;
+; Two, not one, because the commonest typo of all is a transposition -
+; `buidl` for `build` - and plain Levenshtein scores a swap as two
+; edits, not one. A threshold of 1 therefore misses the exact case this
+; exists to catch, which is how it was first measured.
+;
+; A wrong suggestion costs nothing here: the caller only asks after the
+; operand has already failed to open, so there is no reading of the
+; argument under which the invocation was going to work.
+(pub :: nearestSubcommand (-> Int Int))
+(pub fn (nearestSubcommand w) (nearestSubcommandFrom w subcommandNames 0))
+
+(pub :: nearestSubcommandFrom (-> Int Int Int Int))
+(pub fn (nearestSubcommandFrom w v i)
+  (if (>= i (vecLen v))
+      ""
+      (let ((c (cast Int (vecGet v i))))
+        (if (<= (editDistance w c) 2)
+            c
+            (nearestSubcommandFrom w v (+ i 1))))))
+
+; Is `want` present as a FLAG - anywhere in argv, not as another flag's
+; value, and not after `--`?
+;
+; Anywhere is the whole point. `--help` used to be recognised only at
+; argv[1], so `axiom fmt FILE --help` fell through to fmt's write path
+; and rewrote the file it had been asked to explain.
+;
+; After `run`'s own file operand every argument belongs to the PROGRAM,
+; so the scan stops there: `axiom run prog.ax --help` asks prog.ax for
+; its help, not this compiler for its own.
+(pub :: hasFlagAnywhere (-> Int Int Bool))
+(pub fn (hasFlagAnywhere cmd want) (hasFlagAnywhereFrom cmd want 1 0))
+
+(pub :: hasFlagAnywhereFrom (-> Int Int Int Int Bool))
+(pub fn (hasFlagAnywhereFrom cmd want i endOpts)
+  (if (>= i (sysArgc))
+      false
+      (let ((a (sysArg i)))
+        (if (&& (== endOpts 0) (strEq a "--"))
+            false
+        (if (|| (== endOpts 1) (if (looksLikeFlag a) false true))
+            (hasFlagAnywhereFrom cmd want (+ i 1)
+                                 (if (&& (strEq cmd "run") (> i subcommandIndex))
+                                     1 endOpts))
+            (let ((name (flagNamePart a)))
+              (if (strEq name want)
+                  true
+                  (if (&& (== (flagArity name) 1)
+                          (if (flagHasValuePart a) false true))
+                      (hasFlagAnywhereFrom cmd want (+ i 2) endOpts)
+                      (hasFlagAnywhereFrom cmd want (+ i 1) endOpts)))))))))
+
+; Walk argv once and refuse anything the table does not describe.
+;
+; Answers 0 for a well-formed invocation; a bad one never returns,
+; because there is nothing a caller could do with the news.
+(pub :: checkArgs (-> Int Int))
+;@axiom:effect(io)
+(pub fn (checkArgs cmd) (checkArgsFrom cmd 1 0))
+
+(pub :: checkArgsFrom (-> Int Int Int Int))
+;@axiom:effect(io)
+(pub fn (checkArgsFrom cmd i endOpts)
+  (if (>= i (sysArgc))
+      0
+      (let ((a (sysArg i)))
+        (if (&& (== endOpts 0) (strEq a "--"))
+            ; Everything after `--` is an operand, so a file whose name
+            ; begins with `-` can be named at all. driver.ax has carried
+            ; a note since the subcommand CLI landed that this was the
+            ; fix if it ever mattered; validation is what makes it
+            ; matter, since a leading dash is now an error rather than a
+            ; silent skip.
+            (checkArgsFrom cmd (+ i 1) 1)
+        (if (|| (== endOpts 1) (if (looksLikeFlag a) false true))
+            (checkArgsFrom cmd (+ i 1)
+                           (if (&& (strEq cmd "run") (> i subcommandIndex))
+                               1 endOpts))
+            (let ((name (flagNamePart a)))
+              (let ((ar (flagArity name)))
+                (if (< ar 0)
+                    (usageError (cat3 "error: unrecognised flag `" name "`\n"))
+                (if (flagUnimplemented name)
+                    (usageError (cat3 "error: `" name "` is not supported by this compiler.\n       The tracing collector it selected belonged to the retired\n       Rust implementation; this compiler has only the bump\n       allocator. See docs/self-hosting.md section 8.4.\n"))
+                (if (&& (== ar 0) (flagHasValuePart a))
+                    (usageError (cat2 (cat3 "error: `" name "` takes no value, but `")
+                                      (cat2 (flagValuePart a) "` was given\n")))
+                (if (&& (== ar 1) (if (flagHasValuePart a) false true))
+                    (if (>= (+ i 1) (sysArgc))
+                        (usageError (cat3 "error: a value is required for `" name
+                                          "` but none was given\n"))
+                        {
+                          (checkFlagValue name (sysArg (+ i 1)))
+                          (checkArgsFrom cmd (+ i 2) endOpts)
+                        })
+                    {
+                      (if (flagHasValuePart a)
+                          (checkFlagValue name (flagValuePart a))
+                          0)
+                      (checkArgsFrom cmd (+ i 1) endOpts)
+                    })))))))))))
+
+; The values that have exactly one right shape are checked HERE, in the
+; same walk as the names, so a wrong command line is refused before any
+; subcommand acts on it.
+;
+; `--opt` was previously parsed where it is USED, which in `build` is
+; after `compileFile` has already run - so `axiom build --input bad.ax
+; --opt banana` reported the type error, and only mentioned the bad
+; optimisation level on the next run, after the user had fixed the
+; first thing. A command line that cannot be honoured should be refused
+; before the compiler does a minute of work on it.
+;
+; `--diagnostic-format` is deliberately NOT here: an unknown value there
+; warns and falls back to `human`, which is the retired compiler's
+; behaviour and the right one for a presentation flag - a typo should
+; degrade the report, not fail the build. `--target` is not here either,
+; because `checkedTargetCode` already refuses it by name with the list
+; of valid targets.
+(pub :: checkFlagValue (-> Int Int Int))
+;@axiom:effect(io)
+(pub fn (checkFlagValue name v)
+  (if (strEq name "--opt")
+      (if (&& (== (strLen v) 1)
+              (let ((c (strByte v 0))) (&& (>= c 48) (<= c 51))))
+          0
+          (usageError (cat3 "error: `--opt` takes 0, 1, 2 or 3, but was given `" v "`\n")))
+      0))

--- a/self_host/main.ax
+++ b/self_host/main.ax
@@ -77,16 +77,22 @@
           0
         })))
 
-; Exit status is the driver's answer, not a byte count: 0 on success, 1
-; when the source could not be read, 2 when it could not be parsed, 1
-; when the module does not type-check. The previous version returned
-; whatever `writeStdout` did, so a successful run exited with the length
-; of its own output.
+; Exit status is the driver's answer, not a byte count: 0 on success and
+; 1 when the source could not be read, could not be parsed, has no entry
+; point, or does not type-check. The previous version returned whatever
+; `writeStdout` did, so a successful run exited with the length of its
+; own output.
 ;
-; The input path is the first command-line argument, defaulting to
-; `in.ax` so existing harnesses keep working. `sysArg`'s Str wraps the
-; process's own NUL-terminated argv bytes without copying, so its
-; `strData` is exactly the C string `sysReadFile` wants.
+; The input path is the first command-line argument. It used to default
+; to `in.ax` when there was none, which is why a bare `axiom` answered
+; `cannot read input: in.ax` - naming a file the user had never typed.
+; The five harnesses that relied on that default all `cp` their case to
+; `in.ax` first, so each now passes the name explicitly and a bare
+; invocation is free to print the usage instead.
+;
+; `sysArg`'s Str wraps the process's own NUL-terminated argv bytes
+; without copying, so its `strData` is exactly the C string
+; `sysReadFile` wants.
 ;
 ; Import resolution happens HERE rather than inside `emitModule`,
 ; because the type checker needs the resolved declaration list too - a
@@ -98,22 +104,103 @@
 ; stage0 uses, so a differential gate can compare the two streams
 ; separately. An error refuses to emit: a program that does not check
 ; has no business producing an object file.
+; ------------------------------------------------------------------
+; Reading the input, and saying what went wrong when it cannot be read.
+; ------------------------------------------------------------------
+
+; The C library's own wording for the three errnos a source path
+; realistically produces. Anything else is reported by number rather
+; than guessed at, because a wrong reason is worse than a bare one.
+(pub :: errnoReason (-> Int Int))
+(pub fn (errnoReason e)
+  (if (== e 2) "No such file or directory"
+  (if (== e 13) "Permission denied"
+  (if (== e 21) "Is a directory"
+      (cat2 "errno " (decStr e))))))
+
+; 0 when `fileName` can be read, otherwise the errno explaining why not.
+;
+; `sysReadFile` answers "" for a missing file, an EMPTY file, and a
+; DIRECTORY alike - three different facts collapsed into one, which is
+; why an empty file used to be reported as unreadable (a statement about
+; the filesystem, and a false one) and a directory as missing. Opening
+; separates the first: ENOENT and EACCES are refused there. A one-byte
+; read separates the third, because both Darwin and Linux open a
+; directory happily and defer EISDIR to `read` (probed, 2026-08-08).
+(pub :: sourceReadErrno (-> Int Int))
+;@axiom:effect(io)
+(pub fn (sourceReadErrno fileName)
+  (let ((fd (sysOpenPath (strData fileName) 0)))
+    (if (sysFailed fd)
+        (sysErrno fd)
+        (let ((probe (strAlloc 1)))
+          (let ((n (sysReadFd fd (strData probe) 1)))
+            {
+              (sysCloseFd fd)
+              (if (< n 0) (sysErrno n) 0)
+            })))))
+
+; One spelling of the read failure, everywhere.
+;
+; There were three. `fmt` and `symbols` said `Failed to read file 'F'`,
+; the compile path said `cannot read input: F`, and neither gave the
+; reason - so which wording a user saw depended on which subcommand they
+; had typed, and no wording ever said whether the file was missing,
+; unreadable, or a directory.
+(pub :: readFailMsg (-> Int Int Int))
+(pub fn (readFailMsg fileName e)
+  (cat2 (cat3 "Failed to read file '" fileName "': ") (cat2 (errnoReason e) "\n")))
+
+; Does this declaration list define a `main` function?
+;
+; The entry point is what turns a module into a program, and until this
+; existed nothing checked for it: `emitFnDef` renames the entry file's
+; `main` to `__axiom_user_main` and the prelude's argv wrapper calls
+; that symbol, so a file with no `main` emitted a call to a function
+; nobody defined. The failure surfaced from `opt`, as `use of undefined
+; value '@__axiom_user_main'` against a temporary `.ll` that had already
+; been deleted, blaming a native tool for the program's own omission.
+; AX4001 has been in the code table and in `axiom explain` the whole
+; time, with no site constructing it.
+(pub :: declsHaveMain (-> Int Bool))
+(pub fn (declsHaveMain ds) (declsHaveMainFrom ds 0))
+
+(pub :: declsHaveMainFrom (-> Int Int Bool))
+(pub fn (declsHaveMainFrom ds i)
+  (if (>= i (vecLen ds))
+      false
+      (let ((d (vecGet ds i)))
+        (if (&& (== (nodeTag d) TAG_D_FN) (strEq (nodeA d) "main"))
+            true
+            (declsHaveMainFrom ds (+ i 1))))))
+
 ; Compile `fileName` for `tname`, answering its LLVM text - or the empty
 ; string when `doEmit` is 0, which is what `check` wants.
 ;
+; `needMain` is 1 for the subcommands that produce an executable -
+; `build` and `run` - and 0 for `check`, `emit-llvm` and the legacy
+; `axiom FILE` spelling. That split is stage0's: its `build` tested the
+; generated module for an entry point and its `emit_llvm` did not, so a
+; library module can still be checked and can still have its IR read.
+;
 ; Every failure exits from inside here rather than being returned,
 ; because each has its own status and each has already said what went
-; wrong: 1 unreadable input, 2 a parse error, 3 an unresolvable import,
-; 1 again for a module that does not type-check. Threading four codes
-; back through a language with no sum type at this layer would buy
-; nothing - no caller has a second thing to try.
-(pub :: compileFile (-> Int Int Int Int))
+; wrong: 1 an unreadable input, a parse error, a missing entry point, or
+; a module that does not type-check. Threading the codes back through a
+; language with no sum type at this layer would buy nothing - no caller
+; has a second thing to try.
+(pub :: compileFile (-> Int Int Int Int Int))
 ;@axiom:effect(io)
-(pub fn (compileFile fileName tname doEmit)
-  (let ((src (sysReadFile (strData fileName)))
+(pub fn (compileFile fileName tname doEmit needMain)
+  (let ((rerr (sourceReadErrno fileName))
         (dfmt diagFormatArg))
-    (if (== (strLen src) 0)
-        (die (cat3 "cannot read input: " fileName "\n") 1)
+    (if (!= rerr 0)
+        (die (readFailMsg fileName rerr) 1)
+        ; An empty file is READ, not refused: it lexes to no tokens and
+        ; parses to a module with no declarations, which `check` accepts
+        ; and `build` rejects for having no `main` - the same answers
+        ; stage0 gave. It used to be refused as unreadable.
+        (let ((src (sysReadFile (strData fileName))))
         (let ((toks (lex src)))
         ; Lexical errors come first, because lexing does - and because
         ; a file with a bad escape in it has not got a token stream
@@ -184,8 +271,38 @@
                             }
                             (if (== doEmit 0)
                                 ""
-                                (emitResolved allDecls bares fulls tcode)))
-                      }))))))))))))
+                                ; The entry point is checked HERE, after
+                                ; the module type-checks and before a
+                                ; byte of IR exists, because the wrapper
+                                ; that calls `__axiom_user_main` is
+                                ; emitted unconditionally: without this,
+                                ; the omission surfaced from `opt` as
+                                ; `use of undefined value`, against a
+                                ; temporary file already deleted, with
+                                ; exit 4 blaming the toolchain.
+                                ;
+                                ; Spanless, because the diagnostic is
+                                ; about the module rather than about any
+                                ; position in it - there is no `main` to
+                                ; point at. The renderer's `--> <file>`
+                                ; form still names the file.
+                                (if (&& (== needMain 1)
+                                        (if (declsHaveMain allDecls) false true))
+                                    (let ((mds (let ((v vecNew))
+                                                 { (vecPush v
+                                                     (mkDiag SEV_ERROR "AX4001" "missing-main" 0
+                                                             "no `main` function found"
+                                                             0 0
+                                                             "add `(:: main Int)` and `(define main ...)` as the program entry point"))
+                                                   v })))
+                                      {
+                                        (writeStderr (renderDiagsFormat dfmt mds units))
+                                        (writeStderr (renderFailTrailer 1))
+                                        (sysExitWith 1)
+                                        ""
+                                      })
+                                    (emitResolved allDecls bares fulls tcode))))
+                      })))))))))))))
 
 ; The entry point: a subcommand if the first argument names one, and
 ; otherwise the original `stage1 FILE [TARGET]` spelling.
@@ -196,37 +313,98 @@
 ;@axiom:effect(io)
 (pub fn (main)
   (let ((first subcommandName))
+    {
+      ; Refuse a malformed invocation BEFORE anything acts on it. This
+      ; is what stops `axiom fmt --check=true FILE` and
+      ; `axiom fmt FILE --help` from rewriting the file: both used to
+      ; reach fmt's write path, because `hasFlag` matched exactly and
+      ; `--help` was recognised only at argv[1].
+      (checkArgs first)
+      ; Help the user ASKED for: stdout, exit 0, from anywhere in argv.
+      ; `--version`/`-V` is deliberately NOT accepted after a
+      ; subcommand - the retired compiler did not propagate it either -
+      ; so `axiom run prog.ax -V` forwards `-V` to the program.
+      (if (hasFlagAnywhere first "--help")
+          { (writeStdout (helpForCommand first)) (sysExitWith 0) 0 }
+          (if (hasFlagAnywhere first "-h")
+              { (writeStdout (helpForCommand first)) (sysExitWith 0) 0 }
+              0))
+      (if (== (strLen first) 0) (rejectTypoedSubcommand) 0)
     (if (> (strLen first) 0)
         (runSubcommand first)
         ; The original spelling: the first positional is the input, the
         ; second is the target. Positions rather than argv indices,
         ; because a global flag may sit in front of either.
         (let ((i1 (positionalIndex 1)))
-        (let ((fileName (if (< i1 0) "in.ax" (sysArg i1)))
+        ; No subcommand and no file: print the usage rather than a
+        ; complaint about `in.ax`, a filename the user never typed and
+        ; which only exists as this fallback's default. A bare `axiom`
+        ; said `cannot read input: in.ax` and exited 1, which reads as a
+        ; missing file rather than as a missing argument.
+        (if (< i1 0)
+            (die usageText 1)
+        (let ((fileName (sysArg i1))
+              ; `i1` is known good here, so the target scan starts
+              ; one past it unconditionally.
               (tname (let ((v (flagValue "--target" 1)))
                        (if (> (strLen v) 0)
                            v
-                           (let ((i2 (if (< i1 0) (- 0 1) (positionalIndex (+ i1 1)))))
+                           (let ((i2 (positionalIndex (+ i1 1))))
                              (if (< i2 0) hostTarget (sysArg i2)))))))
-          (let ((ir (compileFile fileName tname 1)))
+          (let ((ir (compileFile fileName tname 1 0)))
             {
               (writeStdout ir)
               0
-            }))))))
+            })))))}))
+
+; `axiom buidl f.ax` used to be read as the legacy `axiom FILE TARGET`
+; with FILE=`buidl`, so the answer was `cannot read input: buidl` - a
+; file error naming a word the user meant as a command, with their
+; actual filename silently discarded.
+;
+; The two readings are genuinely ambiguous, because the legacy spelling
+; makes ANY first positional a filename. The tie is broken by asking
+; the filesystem: a first operand that cannot be read AND is within one
+; edit of a subcommand is a typo, not a file. A name that is neither
+; keeps the old answer, which for the legacy grammar is the right one.
+(pub :: rejectTypoedSubcommand Int)
+;@axiom:effect(io)
+(pub fn (rejectTypoedSubcommand)
+  (let ((i (positionalIndex 1)))
+    (if (< i 0)
+        0
+        (let ((w (sysArg i)))
+          (if (== (sourceReadErrno w) 0)
+              0
+              (let ((near (nearestSubcommand w)))
+                (if (== (strLen near) 0)
+                    0
+                    (usageError (cat2 (cat3 "error: unrecognised subcommand `" w "`\n")
+                                      (cat3 "       did you mean `" near "`?\n"))))))))))
 
 (pub :: runSubcommand (-> Int Int))
 ;@axiom:effect(io)
 (pub fn (runSubcommand cmd)
   (if (|| (strEq cmd "help") (|| (strEq cmd "--help") (strEq cmd "-h")))
-      { (writeStdout usageText) 0 }
-  (if (|| (strEq cmd "version") (strEq cmd "--version"))
+      ; `axiom help build` answers for `build`. The operand used to be
+      ; read and discarded, so it printed the general usage - while the
+      ; COMMANDS block promised `help <COMMAND>` would do this. A usage
+      ; text that documents behaviour the binary does not have is the
+      ; same defect as a diagnostic code nothing constructs.
+      ;
+      ; An operand that names no command falls back to the general
+      ; usage rather than failing: `help` is where someone goes when
+      ; they are already lost, and refusing them there is unkind.
+      (let ((topic (positionalFrom operandStart)))
+        { (writeStdout (if (isSubcommand topic) (helpForCommand topic) usageText)) 0 })
+  (if (|| (strEq cmd "version") (|| (strEq cmd "--version") (strEq cmd "-V")))
       { (writeStdout "axiom (self-hosted) 0.1.0\n") 0 }
   (if (strEq cmd "check")
       (let ((f (positionalFrom operandStart)))
         (if (== (strLen f) 0)
             (die "error: check needs an input file\n" 1)
             {
-              (compileFile f (targetArg hostTarget) 0)
+              (compileFile f (targetArg hostTarget) 0 0)
               ; stage0's check prints `OK` on stdout whenever it does
               ; not fail - success and warnings-only alike, in every
               ; diagnostic format (probed 2026-08-07). compileFile
@@ -238,13 +416,18 @@
       (let ((f (positionalFrom operandStart)))
         (if (== (strLen f) 0)
             (die "error: emit-llvm needs an input file\n" 1)
-            (let ((ir (compileFile f (targetArg hostTarget) 1))
-                  (out (flagValue "-o" 1)))
+            ; `--output` is read as well as `-o`. Only `-o` used to be,
+            ; so `axiom emit-llvm f.ax --output out.ll` silently ignored
+            ; the flag, put 57 KB of IR on the terminal, and exited 0 -
+            ; a build script cannot detect that, because nothing failed.
+            (let ((ir (compileFile f (targetArg hostTarget) 1 0))
+                  (out (let ((v (flagValue "-o" 1)))
+                         (if (> (strLen v) 0) v (flagValue "--output" 1)))))
               (if (== (strLen out) 0)
                   { (writeStdout ir) 0 }
                   (if (< (sysWriteFile (strCStr out) ir) 0)
-                      (die "error: could not write LLVM IR\n" 4)
-                      0)))))
+                      (die (cat3 "error: could not write LLVM IR to '" out "'\n") 4)
+                      { (writeStdout (cat3 "LLVM IR written to " out "\n")) 0 })))))
   (if (strEq cmd "build")
       ; `--input`/`--output` are stage0's spelling. A bare positional is
       ; accepted for `--input` too, because a compiler that insists on a
@@ -254,12 +437,46 @@
                    (if (> (strLen v) 0) v (positionalFrom operandStart)))))
         (if (== (strLen inp) 0)
             (die "error: build needs an input file\n" 1)
+            ; `-o` is the short form of `--output` here as well as under
+            ; `emit-llvm`. It used to be read only by `emit-llvm`, so
+            ; `axiom build -o prog f.ax` consumed `prog` as a flag value
+            ; and wrote the default `output` instead - while the usage
+            ; text listed `-o <PATH>` with no qualification. A flag the
+            ; help documents and the binary ignores is the same defect
+            ; as a diagnostic code nothing constructs.
+            ;
+            ; The retired compiler made `-o` the short form of `--opt`
+            ; under `build` and of `--output` under `emit-llvm`. That is
+            ; a wart rather than a contract, and it is not reproduced:
+            ; one letter meaning two unrelated things across sibling
+            ; subcommands is how a build script writes its executable to
+            ; a file named `3`.
             (let ((outp (let ((v (flagValue "--output" 1)))
-                          (if (> (strLen v) 0) v "output"))))
-              (let ((ir (compileFile inp (targetArg hostTarget) 1)))
+                          (if (> (strLen v) 0)
+                              v
+                              (let ((sh (flagValue "-o" 1)))
+                                (if (> (strLen sh) 0) sh "output"))))))
+              (let ((ir (compileFile inp (targetArg hostTarget) 1 1)))
                 (let ((rc (buildToExecutable ir outp optLevelArg
-                                             (if (hasFlag "--emit-llvm") 1 0))))
-                  (if (!= rc 0) (die "" rc) 0))))))
+                                             (if (hasFlagAnywhere cmd "--emit-llvm") 1 0))))
+                  (if (!= rc 0)
+                      (die "" rc)
+                      ; A successful build used to print NOTHING, so a
+                      ; user could not tell it from a no-op, and had to
+                      ; go looking for the file to find out. The retired
+                      ; compiler also printed `[1/5] Lexing...` and four
+                      ; more phase labels; those are not reproduced -
+                      ; they are content-free, they numbered one step
+                      ; twice whenever the entry file had imports, and
+                      ; `run` inherited them onto stdout in front of the
+                      ; program's own output.
+                      {
+                        (if (hasFlagAnywhere cmd "--emit-llvm")
+                            (writeStdout (cat3 "LLVM IR written to " outp ".ll\n"))
+                            0)
+                        (writeStdout (cat3 "Build successful: " outp "\n"))
+                        0
+                      }))))))
   (if (strEq cmd "fmt")
       ; `fmt FILE [--check]`: format in place, or report whether the
       ; file would change. Verification runs before any write - the
@@ -276,17 +493,17 @@
       (let ((f (fmtInputArg 0)))
         (if (== (strLen f) 0)
             (die "error: fmt needs an input file\n" 1)
-            (let ((fd (sysOpenPath (strData f) 0)))
-              (if (sysFailed fd)
-                  (die (cat3 "Failed to read file '" f "'\n") 1)
+            (let ((rerr (sourceReadErrno f)))
+              (if (!= rerr 0)
+                  (die (readFailMsg f rerr) 1)
                   {
-                    (sysCloseFd fd)
+                    0
                     (let ((src (sysReadFile (strData f))))
                       (let ((res (fmtFormat src)))
                         (if (== (fzOk res) 0)
                             (die (cat2 f " was not rewritten: formatter refusal\n") 1)
                             (let ((text (fzText res)))
-                              (if (hasFlag "--check")
+                              (if (hasFlagAnywhere cmd "--check")
                                   (if (strEq src text)
                                       { (writeStdout (cat3 "OK: " f " is already formatted\n")) 0 }
                                       (die (cat3 "Error: " f " needs formatting\n") 1))
@@ -304,9 +521,10 @@
             (dfmt diagFormatArg))
         (if (== (strLen f) 0)
             (die "error: symbols needs an input file\n" 1)
-            (let ((src (sysReadFile (strData f))))
-              (if (== (strLen src) 0)
-                  (die (cat3 "Failed to read file '" f "'\n") 1)
+            (let ((rerr (sourceReadErrno f)))
+              (if (!= rerr 0)
+                  (die (readFailMsg f rerr) 1)
+                  (let ((src (sysReadFile (strData f))))
                   (let ((pr (parseModuleWith (lex src) (scanAxtags src))))
                     (if (== (memGetWord pr 0) 0)
                         (die "compilation failed due to a syntax error\n" 1)
@@ -337,9 +555,9 @@
                                       (symbolsFormatNotice)
                                       (writeStdout
                                         (symbolsRender tc
-                                          (if (hasFlag "--builtins") 1 0)))
+                                          (if (hasFlagAnywhere cmd "--builtins") 1 0)))
                                       0
-                                    }))))))))))))
+                                    })))))))))))))
   (if (strEq cmd "explain")
       ; `explain [CODE] [--list]`: the texts live in explain.ax,
       ; generated byte-for-byte from stage0's own output. `--list`
@@ -347,11 +565,11 @@
       ; an unknown code is two stderr lines and exit 1, echoing the
       ; code AS TYPED, before normalisation.
       (let ((code (positionalFrom operandStart)))
-        (if (|| (hasFlag "--list") (== (strLen code) 0))
+        (if (|| (hasFlagAnywhere cmd "--list") (== (strLen code) 0))
             {
               (writeStdout explainListText)
               (if (&& (== (strLen code) 0)
-                      (if (hasFlag "--list") false true))
+                      (if (hasFlagAnywhere cmd "--list") false true))
                   (writeStdout "\nUsage: axiom explain <CODE>\n")
                   0)
               0
@@ -366,7 +584,7 @@
                   }
                   { (writeStdout text) 0 }))))
   (if (strEq cmd "repl")
-      (replMain (if (hasFlag "--no-banner") 1 0))
+      (replMain (if (hasFlagAnywhere cmd "--no-banner") 1 0))
   (if (strEq cmd "lsp")
       ; The language server speaks JSON-RPC over stdin/stdout, so it
       ; takes no operand and prints nothing else to stdout - anything
@@ -376,7 +594,7 @@
       (let ((f (positionalFrom operandStart)))
         (if (== (strLen f) 0)
             (die "error: run needs an input file\n" 1)
-            (let ((ir (compileFile f hostTarget 1)))
+            (let ((ir (compileFile f hostTarget 1 1)))
               ; Unlike stage0, `run` optimises. stage0 pins its `run` at
               ; --opt 0, which is survivable for a small program and is
               ; not for this compiler: without `opt`'s tail-call pass a
@@ -438,17 +656,26 @@
 ; after it, and `--check` takes no value.
 (pub :: inputArgSkipping (-> Int Int))
 (pub fn (inputArgSkipping bare)
-  (let ((n (sysArgc)) (mut i operandStart) (mut f ""))
+  (let ((n (sysArgc)) (mut i operandStart) (mut f "") (mut endOpts 0))
     {
       (while (< i n)
         (let ((a (sysArg i)))
           {
-            (if (&& (== (strLen f) 0)
-                    (if (strEq a bare)
-                        false
-                        (if (strStartsWith a "-") false true)))
-                (set f a)
-                0)
+            ; `--` ends option parsing here too. `fmt` and `symbols` do
+            ; not use the general positional walk - its flag-skipping
+            ; would swallow the file in `fmt --check FILE` - so the
+            ; separator has to be honoured in both places or it works
+            ; for some subcommands and not others.
+            (if (&& (== endOpts 0) (strEq a "--"))
+                (set endOpts 1)
+                (if (&& (== (strLen f) 0)
+                        (if (strEq a bare)
+                            false
+                            (if (== endOpts 1)
+                                true
+                                (if (strStartsWith a "-") false true))))
+                    (set f a)
+                    0))
             (set i (+ i 1))
           }))
       f
@@ -457,17 +684,47 @@
 (pub :: fmtInputArg (-> Int Int))
 (pub fn (fmtInputArg _u) (inputArgSkipping "--check"))
 
-; argv for the program `run` spawns: its own name and nothing else.
-; Forwarding the driver's remaining arguments is stage0 behaviour this
-; does not yet reproduce, and is recorded rather than half-done.
+; argv for the program `run` spawns: its own name, then every argument
+; that followed the source file.
+;
+; It used to be the name and nothing else, so `axiom run prog.ax a b`
+; started prog.ax with argc 1 and the arguments silently dropped - a
+; program that reads argv could not be run with any at all. The
+; retired compiler forwarded them, and its `Run { input, args }` is
+; where the shape comes from.
+;
+; Everything after the file operand belongs to the PROGRAM, which is
+; also why `checkArgs` stops validating there: `axiom run prog.ax
+; --verbose` passes `--verbose` on rather than refusing it as a flag
+; this compiler does not know. A leading-dash argument that would
+; otherwise be ambiguous can be forced across with `--`.
 (pub :: runArgv (-> Int Int))
 (pub fn (runArgv name)
-  (let ((v (memAlloc 16)))
-    {
-      (memSetWord v 0 (strCStr (strDup name)))
-      (memSetWord v 1 0)
-      v
-    }))
+  (let ((first (+ (positionalIndex operandStart) 1))
+        (n (sysArgc)))
+    (let ((extra (if (< (positionalIndex operandStart) 0) n first)))
+      (let ((v (memAlloc (* (+ (- n extra) 2) 8))))
+        {
+          (memSetWord v 0 (strCStr (strDup name)))
+          (fillRunArgv v extra n 1)
+          v
+        }))))
+
+; Copy argv[from..to) into `v` starting at slot `slot`, NUL-terminated.
+;
+; `--` is dropped as it passes: it is this compiler's end-of-options
+; marker, not an argument the program asked for.
+(pub :: fillRunArgv (-> Int Int Int Int Int))
+(pub fn (fillRunArgv v from to slot)
+  (if (>= from to)
+      { (memSetWord v slot 0) 0 }
+      (let ((a (sysArg from)))
+        (if (strEq a "--")
+            (fillRunArgv v (+ from 1) to slot)
+            {
+              (memSetWord v slot (strCStr (strDup a)))
+              (fillRunArgv v (+ from 1) to (+ slot 1))
+            }))))
 
 (pub :: die (-> Int Int Int))
 (pub fn (die msg code)


### PR DESCRIPTION
Two spellings of `fmt` destroyed the file they were given and reported success:

    axiom fmt --check=true prog.ax   ->  "OK: prog.ax formatted", exit 0
    axiom fmt prog.ax --help         ->  "OK: prog.ax formatted", exit 0

Both are the same defect. Argument parsing was three independent walks over argv - `flagValue`, `hasFlag`, `positionalIndex` - each with its own idea of what a flag is, and none able to say that a flag was not one. `hasFlag` matched EXACTLY, so `--check=true` was not `--check`; `--help` was recognised only at argv[1], so a trailing one was skipped. In both cases the fmt arm fell through to the write path, because an unrecognised `-word` was stepped over, and stepping over is indistinguishable from accepting.

The same blindness ran through everything else. `axiom check --bogus f.ax` printed OK and exited 0, so a mistyped `--diagnostic-formt=json` silently produced human output. `axiom emit-llvm f.ax --output out.ll` ignored the flag, put 57 KB of IR on the terminal and exited 0 - a failure no build script can detect, because nothing failed. `axiom buidl f.ax` was read as the legacy `FILE TARGET` spelling with FILE=`buidl`, so the answer was `cannot read input: buidl` and the user's actual filename was discarded. `axiom build --help` answered `error: build needs an input file`, and `axiom repl --help` dropped the user into the REPL.

WHAT CHANGED

One validating pass now runs before any subcommand acts. The rule is deliberately the weakest one that kills the whole class: a flag must EXIST in the table and must be given the right number of values. It does NOT police which subcommand owns which flag - `--emit-llvm`, `--check`, `--builtins` and `--list` are still accepted on the legacy no-subcommand spelling, because check-driver.sh requires exactly that and ownership would have flipped five of its cases while fixing nothing a user can see. `--` ends option parsing, which is the fix driver.ax's header has named since the subcommand CLI landed.

`--help`/`-h` is honoured anywhere, per subcommand, on stdout with exit 0; `--version`/`-V` only before the subcommand, because clap 4.6.4 did not propagate it either and `axiom run prog.ax -V` must forward `-V` to the program. Usage errors exit 2, which the parse-error port left free. An unreadable first operand within two edits of a command name is reported as a mistyped subcommand - two, not one, because the commonest typo is a transposition and Levenshtein scores `buidl`/`build` as two.

`--gc` IS A CAPABILITY THIS COMPILER DOES NOT HAVE, and now says so.

The retired compiler's conservative mark-sweep collector was 1,098 lines in `axiom-codegen/src/gc.rs`, deleted with the crate. Nothing replaced it. The flag was neither implemented nor rejected, so `axiom --gc build` produced a bump-allocator binary and said nothing - while README.md's opening paragraph, docs/reference.md and scripts/bench-datastructures.sh all still promised a collector. `bench-datastructures.sh --gc` was printing "axiom under --gc" over numbers measured on the allocator it existed to compare against. The flag is now a named refusal, the three documents no longer claim it, the benchmark refuses the switch rather than mislabelling its output, and the loss is recorded in docs/self-hosting.md 8.4 as a capability loss rather than a CLI choice.

AX4001 EXISTED IN THE TABLE AND IN `axiom explain`, AND NOTHING BUILT IT

A file with no `main` reached codegen, which emits the argv wrapper's `call @__axiom_user_main` unconditionally, so the omission surfaced from `opt`:

    opt: nm.ll:10:17: error: use of undefined value '@__axiom_user_main'
    error: opt failed                                          (exit 4)

- an internal symbol, a temporary file the driver had already deleted, and exit 4, "a native tool failed", for a program that was simply missing its entry point. It is now AX4001 with the fix in the help text and exit 1, checked after the module type-checks and before any IR exists. Only `build` and `run` require it: `check`, `emit-llvm` and the legacy spelling do not, which is load-bearing, because check-diagnostics.sh sweeps every module in self_host/, stdlib/, tests/stdlib/ and tests/selfhost/ through the legacy form and requires exit 0, and most of those have no `main`.

READING A FILE HAD THREE SPELLINGS AND NO REASON

`cannot read input: F` from the compile path, `Failed to read file 'F'` from fmt and symbols, and nothing distinguishing the cases. `sysReadFile` answers "" for a missing file, an EMPTY file and a DIRECTORY alike, so an empty file was reported as unreadable - a statement about the filesystem, and a false one. An open plus a one-byte read separates them: open refuses ENOENT and EACCES, and both Darwin and Linux open a directory happily and defer EISDIR to `read`. One spelling now, with the reason: `Failed to read file 'adir': Is a directory`. An empty file checks clean and only fails to BUILD, for want of an entry point.

ALSO

`run` forwards the arguments after the file to the program, which it never has - a program reading argv could not be given any. `build` says `Build successful: <output>`; `emit-llvm --output` writes the file and says where. `build -o PATH` now writes to PATH: only `emit-llvm` read `-o`, so `axiom build -o prog f.ax` consumed `prog` as a flag value and wrote the default `output`, while the usage text listed `-o <PATH>` unqualified. `--opt` refuses a value it cannot honour rather than silently building at 1, in both spellings, and it is refused in the validating pass rather than where the value is read - `build` reads it AFTER `compileFile`, so `axiom build --input bad.ax --opt banana` reported the type error and mentioned the bad level only on the next run, once the user had fixed the other thing.

The retired compiler's `[1/5] Lexing...` phase labels are NOT reproduced: they are content-free, they numbered one step twice whenever the entry file had imports, and `run` inherited them onto stdout in front of the program's own output. `repl` was dispatched but missing from the COMMANDS block, and `--check`, `--builtins`, `--list` and `--no-banner` were accepted and documented nowhere; the usage text now lists everything, and a gate asserts that every accepted flag and command appears in `--help` so the two cannot drift again.

Writing that usage text immediately caught two flags it documented that the binary did not honour - the same defect as an unconstructed diagnostic code, found by probing the new surface rather than by any test. `-V` was not in the subcommand set, so it printed the whole usage to stderr and exited 1. And `--` was accepted by the validator and then ignored by the operand scan, so `axiom check -- -weird.ax` still answered `check needs an input file`. Both work now, in the general walk and in the separate scan `fmt` and `symbols` use. `--` also makes `explainNormalize`'s leading-dash stripping reachable for the first time: it has always resolved `-3001`, and nothing could deliver such a code to it.

The EXIT CODES block was wrong in both directions and the errors survived because nothing derived it from the code. It claimed 2 meant "a parse error" - untrue since the parse-error port moved syntax errors to 1, leaving 2 unused - and driver.ax's header claimed 3 was "retired", which was true only of the import path: `dieImport` still exits 3 from four sites, and an entry file importing an unparsable module still does. Both now say what the binary does. Exit 4 is labelled as this compiler's own choice rather than the retired one's, which exited 1 for a failing llc.

The magic `in.ax` default is gone - it is why a bare `axiom` answered `cannot read input: in.ax`, naming a file the user never typed. The five harnesses that relied on it already copied their case to `in.ax`, so each now passes the name explicitly.

WHAT PINS IT

check-driver.sh goes from 18 cases to 74. Every new behaviour was ablated against a compiler built from the previous commit's sources: 26 of them, and all 26 fail there. One did not on the first attempt - `explain -- 3001` passes on the old compiler too, because its operand scan skipped the `--` and found the code anyway - so the case was rewritten as `explain -- -3001`, which only the new scan can reach.

The two data-loss cases assert the FILE comes
back byte-identical rather than asserting a message, which cannot be blessed away because the expected content is what the test itself wrote; `run`'s forwarding is asserted through the program's own exit status (`(fn (main) (sysArgc))` must exit 3 for two arguments) for the same reason.

Full battery green: 17 gates, including the bootstrap fixpoint from the committed seed.

WHAT IS NOT FIXED, deliberately

Extra positional operands are still ignored (`axiom check f.ax extra`), and a flag belonging to another subcommand is still accepted and does nothing (`axiom check --builtins f.ax`). Both are the price of dropping per-subcommand ownership, and both cost a user nothing.

Two divergences from the retired compiler are deliberate. `-o` means `--output` for `build` as well as `emit-llvm`; that compiler made it the short form of `--opt` under `build` and of `--output` under `emit-llvm`, which is a wart rather than a contract - one letter meaning two unrelated things across sibling subcommands is how a build script writes its executable to a file named `3`. And `--opt` refuses anything outside 0-3, where that compiler parsed a u8 and clamped, so `--opt 200` quietly became -O3.